### PR TITLE
150 renderizar imagem de perfil do candidato

### DIFF
--- a/src/controller/candidatoController.js
+++ b/src/controller/candidatoController.js
@@ -406,8 +406,12 @@ const updatePerfil = async (req, res) => {
         candidato.idiomas = idiomas || candidato.idiomas;
 
         // Verificar se uma nova imagem foi enviada
-        if (req.file && req.file.path) {
-            candidato.imagem = req.file.path;
+        if (req.file) {
+            // Salva como Buffer + contentType
+            candidato.imagem = {
+                data: req.file.buffer,
+                contentType: req.file.mimetype
+            };
         }
 
     await candidato.save();

--- a/src/controller/candidatoController.js
+++ b/src/controller/candidatoController.js
@@ -47,10 +47,22 @@ const dashboardCandidato = async (req, res) => {
         // Coleta apenas as areas únicas das vagas retornadas, sem duplicatas
         const areas = [...new Set(vagas.map(vaga => vaga.area))];
 
+        // converte buffer do candidato para base64, se existir
+        let candidatoParaRender;
+        if (candidato && candidato.imagem && candidato.imagem.data) {
+            candidatoParaRender = candidato.toObject(); // converte documento Mongoose em objeto simples
+            candidatoParaRender.imagem = {
+                contentType: candidato.imagem.contentType,
+                data: candidato.imagem.data.toString('base64') // converte Buffer -> base64 string
+            };
+        } else {
+            candidatoParaRender = candidato; // sem imagem
+        }
+
         res.render('can/candidatoDashboard', {
             title: 'Dashboard',
             user: req.session.user,
-            candidato,
+            candidato: candidatoParaRender,
             inDashboard: true,
             style: 'candidatoDashboar.css',
             candidatoId,

--- a/src/controller/telasController.js
+++ b/src/controller/telasController.js
@@ -264,10 +264,18 @@ const visualizarTelaEdicaoCand = async (req, res) => {
             return res.status(404).send('Candidato não encontrado');
         }
 
+        // converte a imagem do candidato para string para a view de edição
+        let candidatoParaView = candidato.toObject();
+        if (candidato && candidato.imagem && candidato.imagem.data) {
+            candidatoParaView.imagem = `data:${candidato.imagem.contentType};base64,${candidato.imagem.data.toString('base64')}`;
+        } else {
+            candidatoParaView.imagem = null;
+        }
+
         res.render('can/perfilEditar', {
             title: 'Edição de Perfil',
             style: 'perfilEditar.css',
-            user: candidato,
+            user: candidatoParaView,
         });
     } catch (erro) {
         console.error(erro);


### PR DESCRIPTION
## 🔄 Pull Request – Correção exibição da imagem de perfil do candidato (visualização e edição)

### 📌 Descrição

Este PR resolve o problema em que a imagem de perfil do candidato não era exibida no modal de visualização e na tela de edição. A falha ocorria porque o controller não estava convertendo corretamente os dados binários (Buffer) armazenados no MongoDB para um formato que o frontend consiga renderizar (Base64 / data URL).

---

### ✅ Alterações realizadas

- Ajuste no updatePerfil (back-end) em `src/controller/candidatoController.js`
  - Implementada a lógica de salvamento da imagem enviada pelo candidato.
  - Agora a imagem é salva como Buffer + contentType, permitindo sua conversão posterior.
 
- Ajuste no dashboard (renderização base64) em `src/controller/candidatoController.js`
  - Antes de enviar os dados para `candidatoDashboard.hbs`, a imagem é convertida para base64
  - Isso garante que o dashboard consiga renderizar a imagem corretamente no HTML.

- Ajuste na função `visualizarTelaEdicaoCand` em `src/controller/telasController.js`
  - Implementada a conversão da imagem do candidato para Data URL
  - Essa abordagem permite que o HTML exiba a imagem

---
Fixes #150